### PR TITLE
Short-term fix for infinite login loop

### DIFF
--- a/src/create-core-app/aad/A01-begin-app/client/identity/identityClient.js
+++ b/src/create-core-app/aad/A01-begin-app/client/identity/identityClient.js
@@ -16,13 +16,10 @@ import { env } from '/modules/env.js';
 const msalConfig = {
     auth: {
         clientId: env.CLIENT_ID,
-        authority: `https://login.microsoftonline.com/${env.TENANT_ID}`,
-        redirectUri: `https://${env.HOSTNAME}`,
-        postLogoutRedirectUri: `https://${env.HOSTNAME}`
     },
     cache: {
-        cacheLocation: "sessionStorage", // This configures where your cache will be stored
-        storeAuthStateInCookie: false    // Set this to "true" if you are having issues on IE11 or Edge
+        cacheLocation: "localStorage", // This configures where your cache will be stored
+        storeAuthStateInCookie: false  // Set this to "true" if you are having issues on IE11 or pre-Chromium Edge
     }
 };
 
@@ -31,7 +28,7 @@ const msalRequest = {
     scopes: [`api://${env.HOSTNAME}/${env.CLIENT_ID}/access_as_user`]
 }
 
-const msalClient = new msal.PublicClientApplication(msalConfig);
+const msalClient = new msal.PublicClientApplication (msalConfig);
 
 let getLoggedInEmployeeIdPromise;        // Cache the promise so we only do the work once on this page
 export function getLoggedinEmployeeId() {
@@ -87,7 +84,8 @@ async function getAccessToken2() {
     if (accounts.length === 1) {
         msalRequest.account = accounts[0];
     } else {
-        throw ("Error: Too many or no accounts logged in");
+        alert("You are already signed in with a different Azure AD; please log out of the other account.");
+        msalClient.logoutRedirect(msalRequest);
     }
 
     let accessToken;

--- a/src/create-core-app/aad/A01-begin-app/client/identity/userPanel.js
+++ b/src/create-core-app/aad/A01-begin-app/client/identity/userPanel.js
@@ -11,6 +11,7 @@ class northwindUserPanel extends HTMLElement {
 
         if (!employee) {
 
+            alert("Employee not found; are you in the right tenant?");
             logoff();
 
         } else {

--- a/src/create-core-app/aad/A02-after-teams-sso/client/identity/identityClient.js
+++ b/src/create-core-app/aad/A02-after-teams-sso/client/identity/identityClient.js
@@ -18,13 +18,10 @@ import 'https://statics.teams.cdn.office.net/sdk/v1.11.0/js/MicrosoftTeams.min.j
 const msalConfig = {
     auth: {
         clientId: env.CLIENT_ID,
-        authority: `https://login.microsoftonline.com/${env.TENANT_ID}`,
-        redirectUri: `https://${env.HOSTNAME}`,
-        postLogoutRedirectUri: `https://${env.HOSTNAME}`
     },
     cache: {
-        cacheLocation: "sessionStorage", // This configures where your cache will be stored
-        storeAuthStateInCookie: false    // Set this to "true" if you are having issues on IE11 or Edge
+        cacheLocation: "localStorage", // This configures where your cache will be stored
+        storeAuthStateInCookie: false  // Set this to "true" if you are having issues on IE11 or pre-Chromium Edge
     }
 };
 
@@ -33,7 +30,7 @@ const msalRequest = {
     scopes: [`api://${env.HOSTNAME}/${env.CLIENT_ID}/access_as_user`]
 }
 
-const msalClient = new msal.PublicClientApplication(msalConfig);
+const msalClient = new msal.PublicClientApplication (msalConfig);
 
 let getLoggedInEmployeeIdPromise;        // Cache the promise so we only do the work once on this page
 export function getLoggedinEmployeeId() {

--- a/src/create-core-app/aad/A02-after-teams-sso/client/identity/userPanel.js
+++ b/src/create-core-app/aad/A02-after-teams-sso/client/identity/userPanel.js
@@ -11,6 +11,7 @@ class northwindUserPanel extends HTMLElement {
 
         if (!employee) {
 
+            alert("Employee not found; are you in the right tenant?");
             logoff();
 
         } else {

--- a/src/create-core-app/aad/A03-after-apply-styling/client/identity/identityClient.js
+++ b/src/create-core-app/aad/A03-after-apply-styling/client/identity/identityClient.js
@@ -18,13 +18,10 @@ import 'https://statics.teams.cdn.office.net/sdk/v1.11.0/js/MicrosoftTeams.min.j
 const msalConfig = {
     auth: {
         clientId: env.CLIENT_ID,
-        authority: `https://login.microsoftonline.com/${env.TENANT_ID}`,
-        redirectUri: `https://${env.HOSTNAME}`,
-        postLogoutRedirectUri: `https://${env.HOSTNAME}`
     },
     cache: {
-        cacheLocation: "sessionStorage", // This configures where your cache will be stored
-        storeAuthStateInCookie: false    // Set this to "true" if you are having issues on IE11 or Edge
+        cacheLocation: "localStorage", // This configures where your cache will be stored
+        storeAuthStateInCookie: false  // Set this to "true" if you are having issues on IE11 or pre-Chromium Edge
     }
 };
 
@@ -33,7 +30,7 @@ const msalRequest = {
     scopes: [`api://${env.HOSTNAME}/${env.CLIENT_ID}/access_as_user`]
 }
 
-const msalClient = new msal.PublicClientApplication(msalConfig);
+const msalClient = new msal.PublicClientApplication (msalConfig);
 
 let getLoggedInEmployeeIdPromise;        // Cache the promise so we only do the work once on this page
 export function getLoggedinEmployeeId() {

--- a/src/create-core-app/aad/A03-after-apply-styling/client/identity/userPanel.js
+++ b/src/create-core-app/aad/A03-after-apply-styling/client/identity/userPanel.js
@@ -11,6 +11,7 @@ class northwindUserPanel extends HTMLElement {
 
         if (!employee) {
 
+            alert("Employee not found; are you in the right tenant?");
             logoff();
 
         } else {

--- a/src/extend-with-capabilities/ConfigurableTab/client/identity/identityClient.js
+++ b/src/extend-with-capabilities/ConfigurableTab/client/identity/identityClient.js
@@ -18,13 +18,10 @@ import 'https://statics.teams.cdn.office.net/sdk/v1.11.0/js/MicrosoftTeams.min.j
 const msalConfig = {
     auth: {
         clientId: env.CLIENT_ID,
-        authority: `https://login.microsoftonline.com/${env.TENANT_ID}`,
-        redirectUri: `https://${env.HOSTNAME}`,
-        postLogoutRedirectUri: `https://${env.HOSTNAME}`
     },
     cache: {
-        cacheLocation: "sessionStorage", // This configures where your cache will be stored
-        storeAuthStateInCookie: false    // Set this to "true" if you are having issues on IE11 or Edge
+        cacheLocation: "localStorage", // This configures where your cache will be stored
+        storeAuthStateInCookie: false  // Set this to "true" if you are having issues on IE11 or pre-Chromium Edge
     }
 };
 
@@ -33,7 +30,7 @@ const msalRequest = {
     scopes: [`api://${env.HOSTNAME}/${env.CLIENT_ID}/access_as_user`]
 }
 
-const msalClient = new msal.PublicClientApplication(msalConfig);
+const msalClient = new msal.PublicClientApplication (msalConfig);
 
 let getLoggedInEmployeeIdPromise;        // Cache the promise so we only do the work once on this page
 export function getLoggedinEmployeeId() {

--- a/src/extend-with-capabilities/ConfigurableTab/client/identity/userPanel.js
+++ b/src/extend-with-capabilities/ConfigurableTab/client/identity/userPanel.js
@@ -11,6 +11,7 @@ class northwindUserPanel extends HTMLElement {
 
         if (!employee) {
 
+            alert("Employee not found; are you in the right tenant?");
             logoff();
 
         } else {

--- a/src/extend-with-capabilities/Deeplink/client/identity/identityClient.js
+++ b/src/extend-with-capabilities/Deeplink/client/identity/identityClient.js
@@ -18,13 +18,10 @@ import 'https://statics.teams.cdn.office.net/sdk/v1.11.0/js/MicrosoftTeams.min.j
 const msalConfig = {
     auth: {
         clientId: env.CLIENT_ID,
-        authority: `https://login.microsoftonline.com/${env.TENANT_ID}`,
-        redirectUri: `https://${env.HOSTNAME}`,
-        postLogoutRedirectUri: `https://${env.HOSTNAME}`
     },
     cache: {
-        cacheLocation: "sessionStorage", // This configures where your cache will be stored
-        storeAuthStateInCookie: false    // Set this to "true" if you are having issues on IE11 or Edge
+        cacheLocation: "localStorage", // This configures where your cache will be stored
+        storeAuthStateInCookie: false  // Set this to "true" if you are having issues on IE11 or pre-Chromium Edge
     }
 };
 
@@ -33,7 +30,7 @@ const msalRequest = {
     scopes: [`api://${env.HOSTNAME}/${env.CLIENT_ID}/access_as_user`]
 }
 
-const msalClient = new msal.PublicClientApplication(msalConfig);
+const msalClient = new msal.PublicClientApplication (msalConfig);
 
 let getLoggedInEmployeeIdPromise;        // Cache the promise so we only do the work once on this page
 export function getLoggedinEmployeeId() {

--- a/src/extend-with-capabilities/Deeplink/client/identity/userPanel.js
+++ b/src/extend-with-capabilities/Deeplink/client/identity/userPanel.js
@@ -11,6 +11,7 @@ class northwindUserPanel extends HTMLElement {
 
         if (!employee) {
 
+            alert("Employee not found; are you in the right tenant?");
             logoff();
 
         } else {

--- a/src/extend-with-capabilities/MessagingExtension/client/identity/identityClient.js
+++ b/src/extend-with-capabilities/MessagingExtension/client/identity/identityClient.js
@@ -18,13 +18,10 @@ import 'https://statics.teams.cdn.office.net/sdk/v1.11.0/js/MicrosoftTeams.min.j
 const msalConfig = {
     auth: {
         clientId: env.CLIENT_ID,
-        authority: `https://login.microsoftonline.com/${env.TENANT_ID}`,
-        redirectUri: `https://${env.HOSTNAME}`,
-        postLogoutRedirectUri: `https://${env.HOSTNAME}`
     },
     cache: {
-        cacheLocation: "sessionStorage", // This configures where your cache will be stored
-        storeAuthStateInCookie: false    // Set this to "true" if you are having issues on IE11 or Edge
+        cacheLocation: "localStorage", // This configures where your cache will be stored
+        storeAuthStateInCookie: false  // Set this to "true" if you are having issues on IE11 or pre-Chromium Edge
     }
 };
 
@@ -33,7 +30,7 @@ const msalRequest = {
     scopes: [`api://${env.HOSTNAME}/${env.CLIENT_ID}/access_as_user`]
 }
 
-const msalClient = new msal.PublicClientApplication(msalConfig);
+const msalClient = new msal.PublicClientApplication (msalConfig);
 
 let getLoggedInEmployeeIdPromise;        // Cache the promise so we only do the work once on this page
 export function getLoggedinEmployeeId() {

--- a/src/extend-with-capabilities/MessagingExtension/client/identity/userPanel.js
+++ b/src/extend-with-capabilities/MessagingExtension/client/identity/userPanel.js
@@ -11,6 +11,7 @@ class northwindUserPanel extends HTMLElement {
 
         if (!employee) {
 
+            alert("Employee not found; are you in the right tenant?");
             logoff();
 
         } else {

--- a/src/extend-with-capabilities/Monetization/client/identity/identityClient.js
+++ b/src/extend-with-capabilities/Monetization/client/identity/identityClient.js
@@ -18,13 +18,10 @@ import 'https://statics.teams.cdn.office.net/sdk/v1.11.0/js/MicrosoftTeams.min.j
 const msalConfig = {
     auth: {
         clientId: env.CLIENT_ID,
-        authority: `https://login.microsoftonline.com/${env.TENANT_ID}`,
-        redirectUri: `https://${env.HOSTNAME}`,
-        postLogoutRedirectUri: `https://${env.HOSTNAME}`
     },
     cache: {
-        cacheLocation: "sessionStorage", // This configures where your cache will be stored
-        storeAuthStateInCookie: false    // Set this to "true" if you are having issues on IE11 or Edge
+        cacheLocation: "localStorage", // This configures where your cache will be stored
+        storeAuthStateInCookie: false  // Set this to "true" if you are having issues on IE11 or pre-Chromium Edge
     }
 };
 
@@ -33,7 +30,7 @@ const msalRequest = {
     scopes: [`api://${env.HOSTNAME}/${env.CLIENT_ID}/access_as_user`]
 }
 
-const msalClient = new msal.PublicClientApplication(msalConfig);
+const msalClient = new msal.PublicClientApplication (msalConfig);
 
 let getLoggedInEmployeeIdPromise;        // Cache the promise so we only do the work once on this page
 export function getLoggedinEmployeeId() {

--- a/src/extend-with-capabilities/Monetization/client/identity/userPanel.js
+++ b/src/extend-with-capabilities/Monetization/client/identity/userPanel.js
@@ -2,8 +2,7 @@ import {
     getLoggedInEmployee,
     logoff
 } from './identityClient.js';
-import { inTeams } from '../modules/teamsHelpers.js';
-import { hasValidLicense } from '../modules/northwindLicensing.js';
+
 class northwindUserPanel extends HTMLElement {
 
     async connectedCallback() {
@@ -12,15 +11,10 @@ class northwindUserPanel extends HTMLElement {
 
         if (!employee) {
 
+            alert("Employee not found; are you in the right tenant?");
             logoff();
 
         } else {
-            if (await inTeams()) {
-                const validLicense = await hasValidLicense();  
-                if (validLicense.status && validLicense.status.toString().toLowerCase()==="failure") {
-                        window.location.href =`/pages/needLicense.html?error=${validLicense.reason}`;
-                }    
-            }
 
             this.innerHTML = `<div class="userPanel">
                 <img src="data:image/bmp;base64,${employee.photo}"></img>

--- a/src/extend-with-capabilities/TaskModule/client/identity/identityClient.js
+++ b/src/extend-with-capabilities/TaskModule/client/identity/identityClient.js
@@ -18,13 +18,10 @@ import 'https://statics.teams.cdn.office.net/sdk/v1.11.0/js/MicrosoftTeams.min.j
 const msalConfig = {
     auth: {
         clientId: env.CLIENT_ID,
-        authority: `https://login.microsoftonline.com/${env.TENANT_ID}`,
-        redirectUri: `https://${env.HOSTNAME}`,
-        postLogoutRedirectUri: `https://${env.HOSTNAME}`
     },
     cache: {
-        cacheLocation: "sessionStorage", // This configures where your cache will be stored
-        storeAuthStateInCookie: false    // Set this to "true" if you are having issues on IE11 or Edge
+        cacheLocation: "localStorage", // This configures where your cache will be stored
+        storeAuthStateInCookie: false  // Set this to "true" if you are having issues on IE11 or pre-Chromium Edge
     }
 };
 
@@ -33,7 +30,7 @@ const msalRequest = {
     scopes: [`api://${env.HOSTNAME}/${env.CLIENT_ID}/access_as_user`]
 }
 
-const msalClient = new msal.PublicClientApplication(msalConfig);
+const msalClient = new msal.PublicClientApplication (msalConfig);
 
 let getLoggedInEmployeeIdPromise;        // Cache the promise so we only do the work once on this page
 export function getLoggedinEmployeeId() {

--- a/src/extend-with-capabilities/TaskModule/client/identity/userPanel.js
+++ b/src/extend-with-capabilities/TaskModule/client/identity/userPanel.js
@@ -11,6 +11,7 @@ class northwindUserPanel extends HTMLElement {
 
         if (!employee) {
 
+            alert("Employee not found; are you in the right tenant?");
             logoff();
 
         } else {


### PR DESCRIPTION
RE: #42 
Hoping this fixes it for now anyway.
The problem seems to occur when a user is inadvertently logged into 2 Azure AD accounts, one that is saved in their browser and the other that they're using to test the labs. The code didn't handle that well and was just re-prompting the user forever. Now it should alert the user and get them to log off of the 2nd account.

 cc/ @fhinkel @dstarr 
